### PR TITLE
changed logging.info to logging.debug

### DIFF
--- a/src/flashbake/plugins/lastfm.py
+++ b/src/flashbake/plugins/lastfm.py
@@ -40,7 +40,7 @@ class LastFM(AbstractMessagePlugin):
 
         # last n items for m creator
         url = "%suser.getrecentTracks&user=%s&api_key=%s&limit=%s&format=json" % (LASTFM, self.user_name, self.api_key, self.limit)
-        logging.info('API call: %s' % url)
+        logging.debug('API call: %s' % url)
         raw_data = self._fetch_data(url)
 
         tracks = raw_data['recenttracks']['track']


### PR DESCRIPTION
The line has been changed from `logging.info` to `logging.debug` so that the API call won't be included in commit messages.