### PR TITLE
Timestamp plugin issue 15

### DIFF
--- a/src/flashbake/plugins/timestamp.py
+++ b/src/flashbake/plugins/timestamp.py
@@ -34,10 +34,10 @@ class Timestamp(AbstractMessagePlugin):
 
         ''' Determine whether the timestamp is in local or UTC time, and whether it uses a 12- or 24-hour clock. '''
 
-        if self.time_format == 'utc' and self.time_hours == '24':
+        if self.time_format == 'utc' or 'UTC' and self.time_hours == '24':
            zone = findtimezone(config)
            message_file.write(str(datetime.datetime.utcnow().strftime('%A, %B %d, %Y %H:%M UTC in ') + str(zone) + '\n'))
-        elif self.time_format == 'utc' and self.time_hours == '12':
+        elif self.time_format == 'utc' or 'UTC' and self.time_hours == '12':
            zone = findtimezone(config)
            message_file.write(str(datetime.datetime.utcnow().strftime('%A, %B %d, %Y %I:%M %p UTC in ') + str(zone) + '\n'))
         elif self.time_format == 'local' and self.time_hours == '24':
@@ -47,4 +47,4 @@ class Timestamp(AbstractMessagePlugin):
            zone = findtimezone(config)
            message_file.write(str(datetime.datetime.now().strftime('%A, %B %d, %Y %I:%M %p in ') + str(zone) + '\n'))
         else:
-           message_file.write('Time format could not be determined. Please specify utc or local time, and a 12- or 24-hour clock in your configuration file. \n')
+           message_file.write('Time format could not be determined. Please specify UTC or local time, and a 12- or 24-hour clock in your configuration file. \n')

--- a/src/flashbake/plugins/timestamp.py
+++ b/src/flashbake/plugins/timestamp.py
@@ -16,9 +16,11 @@
 #    You should have received a copy of the GNU General Public License
 #    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
 
-''' timestamp.py displays the timestamp for a current commit in local or UTC time. '''
+''' timestamp.py displays the timestamp for a current commit in local or UTC time using a 12- or 24-hour clock.
+    thanks to @carlosalonso (on GitHub) for the suggestion. '''
 
 from flashbake.plugins import AbstractMessagePlugin
+from flashbake.plugins.timezone import findtimezone 
 import datetime
 
 
@@ -26,18 +28,23 @@ class Timestamp(AbstractMessagePlugin):
     def __init__(self, plugin_spec):
         AbstractMessagePlugin.__init__(self, plugin_spec, False)
         self.define_property('time_format', required=False)
+        self.define_property('time_hours', required=False)
 
     def addcontext(self, message_file, config):
 
-        ''' add a timestamp in local or UTC time '''
-        if self.time_format == 'utc':
-           message_file.write(str(datetime.datetime.utcnow().strftime('%A, %d %B, %Y %I:%M%p')) + '\n')
-        elif self.time_format == 'local':
-           message_file.write(str(datetime.datetime.now().strftime('%A, %d %B, %Y %I:%M%p')) + '\n')
+        ''' Determine whether the timestamp is in local or UTC time, and whether it uses a 12- or 24-hour clock. '''
+
+        if self.time_format == 'utc' and self.time_hours == '24':
+           zone = findtimezone(config)
+           message_file.write(str(datetime.datetime.utcnow().strftime('%A, %B %d, %Y %H:%M UTC in ') + str(zone) + '\n'))
+        elif self.time_format == 'utc' and self.time_hours == '12':
+           zone = findtimezone(config)
+           message_file.write(str(datetime.datetime.utcnow().strftime('%A, %B %d, %Y %I:%M %p UTC in ') + str(zone) + '\n'))
+        elif self.time_format == 'local' and self.time_hours == '24':
+           zone = findtimezone(config)
+           message_file.write(str(datetime.datetime.now().strftime('%A, %B %d, %Y %H:%M in ') + str(zone) + '\n'))
+        elif self.time_format == 'local' and self.time_hours == '12':
+           zone = findtimezone(config)
+           message_file.write(str(datetime.datetime.now().strftime('%A, %B %d, %Y %I:%M %p in ') + str(zone) + '\n'))
         else:
-           message_file.write('Time format could not be determined. Please specify utc or local time in your configuration file. \n')
-
-        return True
-
-
-
+           message_file.write('Time format could not be determined. Please specify utc or local time, and a 12- or 24-hour clock in your configuration file. \n')

--- a/src/flashbake/plugins/timestamp.py
+++ b/src/flashbake/plugins/timestamp.py
@@ -1,0 +1,43 @@
+#    Copyright 2017 Ian Paul
+#    Copyright 2009 Thomas Gideon
+#
+#    This file is part of flashbake.
+#
+#    flashbake is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    flashbake is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with flashbake.  If not, see <http://www.gnu.org/licenses/>.
+
+''' timestamp.py displays the timestamp for a current commit in local or UTC time. '''
+
+from flashbake.plugins import AbstractMessagePlugin
+import datetime
+
+
+class Timestamp(AbstractMessagePlugin):
+    def __init__(self, plugin_spec):
+        AbstractMessagePlugin.__init__(self, plugin_spec, False)
+        self.define_property('time_format', required=False)
+
+    def addcontext(self, message_file, config):
+
+        ''' add a timestamp in local or UTC time '''
+        if self.time_format == 'utc':
+           message_file.write(str(datetime.datetime.utcnow().strftime('%A, %d %B, %Y %I:%M%p')) + '\n')
+        elif self.time_format == 'local':
+           message_file.write(str(datetime.datetime.now().strftime('%A, %d %B, %Y %I:%M%p')) + '\n')
+        else:
+           message_file.write('Time format could not be determined. Please specify utc or local time in your configuration file. \n')
+
+        return True
+
+
+


### PR DESCRIPTION
This is a new plugin per the suggestion in issue 15. It prints local or UTC time along with the date and current timezone in a user's commit message such as "Monday, August 21, 2017 11:43 UTC in Europe/Paris." If it's the top line in a commit message it helps peruse commits on GitHub since each commit will be titled by date and time. 