### PR TITLE
Twitter unicode problem

### DIFF
--- a/src/flashbake/plugins/twitter.py
+++ b/src/flashbake/plugins/twitter.py
@@ -40,6 +40,6 @@ class Twitter(AbstractMessagePlugin):
           public_tweets = api.user_timeline(screen_name = self.username, count = self.tweet_limit, tweet_mode='extended')
           for tweet in public_tweets:
               if hasattr(tweet, 'retweeted_status'):
-                  message_file.write('RT @' + tweet.retweeted_status.user.screen_name + ': ' + tweet.retweeted_status.full_text.encode('utf-8') + '\n')
+                  message_file.write(unicode('RT @' + tweet.retweeted_status.user.screen_name + ': ' + tweet.retweeted_status.full_text).encode('utf-8') + '\n')
               else:
-                  message_file.write('By Me: ' + tweet.full_text.encode('utf-8') + '\n')
+                  message_file.write(unicode('By Me: ' + tweet.full_text).encode('utf-8') + '\n')


### PR DESCRIPTION
I ran into an edge case with the Twitter plugin where if a tweet had a special character--in this case an ellipsis--it threw an error. This edit fixes that, but now some special characters are printing as unescaped HTML (ampersand, angle brackets, etc.). I've tried to fix that but so far no luck. It could also be a quirk of my terminal as other tools I use--like Jlund's Streisand--have the same problem on my computer.